### PR TITLE
Add a Travis CI file for Continuous Integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: rust

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# radiobrowser-api-rust
+
+experimental rust implementation of radiobrowser-api


### PR DESCRIPTION
This is the same as segler-alex/stream-check-rust#1, but it's designed for the radiobrowser-api-rust repo. The build can be seen in action here: https://travis-ci.org/superusercode/radiobrowser-api-rust/

 [![Build Status](https://travis-ci.org/superusercode/radiobrowser-api-rust.svg?branch=master)](https://travis-ci.org/superusercode/radiobrowser-api-rust)