### PR TITLE
Fix dead link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](code_of_conduct.md) 
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md) 
 # radiobrowser-api-rust
 
 ## What is radiobrowser-api-rust?


### PR DESCRIPTION
The readme link for `CODE_OF_CONDUCT.md` was pointing to the wrong address.