### PR TITLE
change default limit to 1000

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -509,7 +509,7 @@ fn handle_cached_connection<A>(
         param_is_https: ppp.get_bool_opt("is_https")?,
         
         param_offset: ppp.get_number("offset", 0),
-        param_limit: ppp.get_number("limit", 999999),
+        param_limit: ppp.get_number("limit", 1000),
     
         param_seconds: ppp.get_number("seconds", 0),
         param_url: ppp.get_string("url"),

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -509,7 +509,7 @@ fn handle_cached_connection<A>(
         param_is_https: ppp.get_bool_opt("is_https")?,
         
         param_offset: ppp.get_number("offset", 0),
-        param_limit: ppp.get_number("limit", 1000),
+        param_limit: ppp.get_number("limit", 250),
     
         param_seconds: ppp.get_number("seconds", 0),
         param_url: ppp.get_string("url"),

--- a/static/docs.hbs
+++ b/static/docs.hbs
@@ -880,7 +880,7 @@ stepuuid,parent_stepuuid,checkuuid,stationuuid,url,urltype,error,creation_iso860
               </tr>
               <tr>
                 <td>limit</td>
-                <td>100000</td>
+                <td>1000</td>
                 <td>0,1,2,....</td>
                 <td>number of returned datarows (stations) starting with offset</td>
               </tr>
@@ -976,7 +976,7 @@ stepuuid,parent_stepuuid,checkuuid,stationuuid,url,urltype,error,creation_iso860
               </tr>
               <tr>
                 <td>limit</td>
-                <td>100000</td>
+                <td>1000</td>
                 <td>0,1,2,....</td>
                 <td>number of returned datarows (stations) starting with offset</td>
               </tr>
@@ -1071,7 +1071,7 @@ stepuuid,parent_stepuuid,checkuuid,stationuuid,url,urltype,error,creation_iso860
             </tr>
             <tr>
               <td>limit</td>
-              <td>100000</td>
+              <td>1000</td>
               <td>0,1,2,....</td>
               <td>number of returned datarows (stations) starting with offset</td>
             </tr>
@@ -1176,7 +1176,7 @@ stepuuid,parent_stepuuid,checkuuid,stationuuid,url,urltype,error,creation_iso860
             </tr>
             <tr>
               <td>limit</td>
-              <td>100000</td>
+              <td>1000</td>
               <td>0,1,2,....</td>
               <td>number of returned datarows (stations) starting with offset</td>
             </tr>
@@ -1275,7 +1275,7 @@ stepuuid,parent_stepuuid,checkuuid,stationuuid,url,urltype,error,creation_iso860
           </tr>
           <tr>
             <td>limit</td>
-            <td>100000</td>
+            <td>1000</td>
             <td>0,1,2,....</td>
             <td>number of returned datarows (stations) starting with offset</td>
           </tr>
@@ -1367,7 +1367,7 @@ stepuuid,parent_stepuuid,checkuuid,stationuuid,url,urltype,error,creation_iso860
           </tr>
           <tr>
             <td>limit</td>
-            <td>100000</td>
+            <td>1000</td>
             <td>0,1,2,....</td>
             <td>number of returned datarows (stations) starting with offset</td>
           </tr>
@@ -1483,7 +1483,7 @@ stepuuid,parent_stepuuid,checkuuid,stationuuid,url,urltype,error,creation_iso860
           </tr>
           <tr>
             <td>limit</td>
-            <td>100000</td>
+            <td>1000</td>
             <td>0,1,2,....</td>
             <td>number of returned datarows (stations) starting with offset</td>
           </tr>
@@ -1589,7 +1589,7 @@ stepuuid,parent_stepuuid,checkuuid,stationuuid,url,urltype,error,creation_iso860
           </tr>
           <tr>
             <td>limit</td>
-            <td>100000</td>
+            <td>1000</td>
             <td>0,1,2,....</td>
             <td>number of returned datarows (stations) starting with offset</td>
           </tr>
@@ -1659,7 +1659,7 @@ stepuuid,parent_stepuuid,checkuuid,stationuuid,url,urltype,error,creation_iso860
           </tr>
           <tr>
             <td>limit</td>
-            <td>999999</td>
+            <td>1000</td>
             <td>0,1,2,....</td>
             <td>number of returned datarows (checks)</td>
           </tr>
@@ -1990,7 +1990,7 @@ stepuuid,parent_stepuuid,checkuuid,stationuuid,url,urltype,error,creation_iso860
           </tr>
           <tr>
             <td>bitrateMax</td>
-            <td>1000000</td>
+            <td>1000</td>
             <td>POSITIVE INTEGER</td>
             <td>OPTIONAL, maximum of kbps for bitrate field of stations in result</td>
           </tr>
@@ -2037,7 +2037,7 @@ stepuuid,parent_stepuuid,checkuuid,stationuuid,url,urltype,error,creation_iso860
           </tr>
           <tr>
             <td>limit</td>
-            <td>100000</td>
+            <td>1000</td>
             <td>0,1,2,....</td>
             <td>OPTIONAL, number of returned datarows (stations) starting with offset</td>
           </tr>
@@ -2173,7 +2173,7 @@ stepuuid,parent_stepuuid,checkuuid,stationuuid,url,urltype,error,creation_iso860
           </tr>
           <tr>
             <td>limit</td>
-            <td>100000</td>
+            <td>1000</td>
             <td>0,1,2,....</td>
             <td>number of returned datarows (stations) starting with offset</td>
           </tr>
@@ -2232,7 +2232,7 @@ stepuuid,parent_stepuuid,checkuuid,stationuuid,url,urltype,error,creation_iso860
           </tr>
           <tr>
             <td>limit</td>
-            <td>100000</td>
+            <td>1000</td>
             <td>0,1,2,....</td>
             <td>number of returned datarows (stations) starting with offset</td>
           </tr>
@@ -2293,7 +2293,7 @@ stepuuid,parent_stepuuid,checkuuid,stationuuid,url,urltype,error,creation_iso860
           </tr>
           <tr>
             <td>limit</td>
-            <td>100000</td>
+            <td>1000</td>
             <td>0,1,2,....</td>
             <td>number of returned datarows (stations) starting with offset</td>
           </tr>
@@ -2352,7 +2352,7 @@ stepuuid,parent_stepuuid,checkuuid,stationuuid,url,urltype,error,creation_iso860
           </tr>
           <tr>
             <td>limit</td>
-            <td>100000</td>
+            <td>1000</td>
             <td>0,1,2,....</td>
             <td>number of returned datarows (stations) starting with offset</td>
           </tr>
@@ -2412,7 +2412,7 @@ stepuuid,parent_stepuuid,checkuuid,stationuuid,url,urltype,error,creation_iso860
           </tr>
           <tr>
             <td>limit</td>
-            <td>999999</td>
+            <td>1000</td>
             <td>0,1,2,....</td>
             <td>number of returned datarows (changes)</td>
           </tr>
@@ -2461,7 +2461,7 @@ stepuuid,parent_stepuuid,checkuuid,stationuuid,url,urltype,error,creation_iso860
           </tr>
           <tr>
             <td>limit</td>
-            <td>100000</td>
+            <td>1000</td>
             <td>0,1,2,....</td>
             <td>number of returned datarows (stations) starting with offset</td>
           </tr>

--- a/static/docs.hbs
+++ b/static/docs.hbs
@@ -1990,7 +1990,7 @@ stepuuid,parent_stepuuid,checkuuid,stationuuid,url,urltype,error,creation_iso860
           </tr>
           <tr>
             <td>bitrateMax</td>
-            <td>1000</td>
+            <td>1000000</td>
             <td>POSITIVE INTEGER</td>
             <td>OPTIONAL, maximum of kbps for bitrate field of stations in result</td>
           </tr>

--- a/static/docs.hbs
+++ b/static/docs.hbs
@@ -880,7 +880,7 @@ stepuuid,parent_stepuuid,checkuuid,stationuuid,url,urltype,error,creation_iso860
               </tr>
               <tr>
                 <td>limit</td>
-                <td>1000</td>
+                <td>250</td>
                 <td>0,1,2,....</td>
                 <td>number of returned datarows (stations) starting with offset</td>
               </tr>
@@ -976,7 +976,7 @@ stepuuid,parent_stepuuid,checkuuid,stationuuid,url,urltype,error,creation_iso860
               </tr>
               <tr>
                 <td>limit</td>
-                <td>1000</td>
+                <td>250</td>
                 <td>0,1,2,....</td>
                 <td>number of returned datarows (stations) starting with offset</td>
               </tr>
@@ -1071,7 +1071,7 @@ stepuuid,parent_stepuuid,checkuuid,stationuuid,url,urltype,error,creation_iso860
             </tr>
             <tr>
               <td>limit</td>
-              <td>1000</td>
+              <td>250</td>
               <td>0,1,2,....</td>
               <td>number of returned datarows (stations) starting with offset</td>
             </tr>
@@ -1176,7 +1176,7 @@ stepuuid,parent_stepuuid,checkuuid,stationuuid,url,urltype,error,creation_iso860
             </tr>
             <tr>
               <td>limit</td>
-              <td>1000</td>
+              <td>250</td>
               <td>0,1,2,....</td>
               <td>number of returned datarows (stations) starting with offset</td>
             </tr>
@@ -1275,7 +1275,7 @@ stepuuid,parent_stepuuid,checkuuid,stationuuid,url,urltype,error,creation_iso860
           </tr>
           <tr>
             <td>limit</td>
-            <td>1000</td>
+            <td>250</td>
             <td>0,1,2,....</td>
             <td>number of returned datarows (stations) starting with offset</td>
           </tr>
@@ -1367,7 +1367,7 @@ stepuuid,parent_stepuuid,checkuuid,stationuuid,url,urltype,error,creation_iso860
           </tr>
           <tr>
             <td>limit</td>
-            <td>1000</td>
+            <td>250</td>
             <td>0,1,2,....</td>
             <td>number of returned datarows (stations) starting with offset</td>
           </tr>
@@ -1483,7 +1483,7 @@ stepuuid,parent_stepuuid,checkuuid,stationuuid,url,urltype,error,creation_iso860
           </tr>
           <tr>
             <td>limit</td>
-            <td>1000</td>
+            <td>250</td>
             <td>0,1,2,....</td>
             <td>number of returned datarows (stations) starting with offset</td>
           </tr>
@@ -1589,7 +1589,7 @@ stepuuid,parent_stepuuid,checkuuid,stationuuid,url,urltype,error,creation_iso860
           </tr>
           <tr>
             <td>limit</td>
-            <td>1000</td>
+            <td>250</td>
             <td>0,1,2,....</td>
             <td>number of returned datarows (stations) starting with offset</td>
           </tr>
@@ -1659,7 +1659,7 @@ stepuuid,parent_stepuuid,checkuuid,stationuuid,url,urltype,error,creation_iso860
           </tr>
           <tr>
             <td>limit</td>
-            <td>1000</td>
+            <td>250</td>
             <td>0,1,2,....</td>
             <td>number of returned datarows (checks)</td>
           </tr>
@@ -2037,7 +2037,7 @@ stepuuid,parent_stepuuid,checkuuid,stationuuid,url,urltype,error,creation_iso860
           </tr>
           <tr>
             <td>limit</td>
-            <td>1000</td>
+            <td>250</td>
             <td>0,1,2,....</td>
             <td>OPTIONAL, number of returned datarows (stations) starting with offset</td>
           </tr>
@@ -2173,7 +2173,7 @@ stepuuid,parent_stepuuid,checkuuid,stationuuid,url,urltype,error,creation_iso860
           </tr>
           <tr>
             <td>limit</td>
-            <td>1000</td>
+            <td>250</td>
             <td>0,1,2,....</td>
             <td>number of returned datarows (stations) starting with offset</td>
           </tr>
@@ -2232,7 +2232,7 @@ stepuuid,parent_stepuuid,checkuuid,stationuuid,url,urltype,error,creation_iso860
           </tr>
           <tr>
             <td>limit</td>
-            <td>1000</td>
+            <td>250</td>
             <td>0,1,2,....</td>
             <td>number of returned datarows (stations) starting with offset</td>
           </tr>
@@ -2293,7 +2293,7 @@ stepuuid,parent_stepuuid,checkuuid,stationuuid,url,urltype,error,creation_iso860
           </tr>
           <tr>
             <td>limit</td>
-            <td>1000</td>
+            <td>250</td>
             <td>0,1,2,....</td>
             <td>number of returned datarows (stations) starting with offset</td>
           </tr>
@@ -2352,7 +2352,7 @@ stepuuid,parent_stepuuid,checkuuid,stationuuid,url,urltype,error,creation_iso860
           </tr>
           <tr>
             <td>limit</td>
-            <td>1000</td>
+            <td>250</td>
             <td>0,1,2,....</td>
             <td>number of returned datarows (stations) starting with offset</td>
           </tr>
@@ -2412,7 +2412,7 @@ stepuuid,parent_stepuuid,checkuuid,stationuuid,url,urltype,error,creation_iso860
           </tr>
           <tr>
             <td>limit</td>
-            <td>1000</td>
+            <td>250</td>
             <td>0,1,2,....</td>
             <td>number of returned datarows (changes)</td>
           </tr>
@@ -2461,7 +2461,7 @@ stepuuid,parent_stepuuid,checkuuid,stationuuid,url,urltype,error,creation_iso860
           </tr>
           <tr>
             <td>limit</td>
-            <td>1000</td>
+            <td>250</td>
             <td>0,1,2,....</td>
             <td>number of returned datarows (stations) starting with offset</td>
           </tr>


### PR DESCRIPTION
Default value of 999999 seems unreasonable high. It would kill  server and db pretty quickly if many users start clicking links provided in the api documentation, or multiple clients start calling api without pagination params.